### PR TITLE
feat: add authentication section

### DIFF
--- a/packages/starlight-openapi/components/operation/Operation.astro
+++ b/packages/starlight-openapi/components/operation/Operation.astro
@@ -8,6 +8,7 @@ import Md from '../Md.astro'
 import Parameters from '../parameter/Parameters.astro'
 import RequestBody from '../RequestBody.astro'
 import Responses from '../response/Responses.astro'
+import Authorizations from '../security/Authorizations.astro'
 
 import OperationDescription from './OperationDescription.astro'
 
@@ -26,6 +27,7 @@ const isBeta = pathItemOperation.title.includes('[BETA]')
 <OperationDescription operation={pathItemOperation} {schema} />
 <Md text={operation.description} />
 <ExternalDocs docs={operation.externalDocs} />
+<Authorizations />
 <Parameters operation={pathItemOperation} />
 <RequestBody {operation} {schema} />
 <Responses {operation} responses={operation.responses} {schema} />

--- a/packages/starlight-openapi/components/operation/OperationDescription.astro
+++ b/packages/starlight-openapi/components/operation/OperationDescription.astro
@@ -1,6 +1,4 @@
 ---
-import { Icon } from '@astrojs/starlight/components'
-
 import { getOperationURLs, type PathItemOperation } from '../../libs/operation'
 import type { Schema } from '../../libs/schema'
 
@@ -22,11 +20,9 @@ const urls = getOperationURLs(schema.document, pathItemOperation)
   {
     path ? (
       urls.length > 0 ? (
-        <details class="operation-description-urls">
-          <summary>
-            <OperationMethod {method} {path} />
-            <Icon class="caret" name="right-caret" size="1.25rem" />
-          </summary>
+        <details class="operation-description-urls" open={true}>
+          <summary></summary>
+          <OperationMethod {method} {path} />
           <ul>
             {urls.map(({ description, url }) => (
               <OperationUrl {description} {url} />
@@ -42,10 +38,6 @@ const urls = getOperationURLs(schema.document, pathItemOperation)
       <OperationMethod {method} />
     )
   }
-  <div class="extra-links">
-    <a href="/api/authentication">Authentication</a>
-    <a href="/api/errors">Error reference</a>
-  </div>
 </div>
 
 <style>
@@ -54,18 +46,10 @@ const urls = getOperationURLs(schema.document, pathItemOperation)
     background-color: var(--astro-code-color-background);
     border: 1px solid var(--sl-color-gray-5);
     font-size: var(--sl-text-sm);
-    margin-bottom: 2.5rem;
   }
 
   summary {
-    color: var(--sl-color-gray-1);
-    cursor: pointer;
-    justify-content: space-between;
-    list-style-type: none;
-  }
-
-  summary:hover {
-    color: var(--sl-color-gray-2);
+    display: none;
   }
 
   summary,
@@ -81,31 +65,11 @@ const urls = getOperationURLs(schema.document, pathItemOperation)
     display: none;
   }
 
-  .caret {
-    flex-shrink: 0;
-  }
-
-  @media (prefers-reduced-motion: no-preference) {
-    .caret {
-      transition: transform 0.2s ease-in-out;
-    }
-  }
-
-  details[open] .caret {
-    transform: rotateZ(90deg);
-  }
-
-  :global([dir='rtl']) .caret {
-    transform: rotateZ(180deg);
-  }
-
   ul {
     display: flex;
     flex-direction: column;
     gap: 0.8rem;
     list-style-type: none;
-    padding-block-start: 0.5rem;
-    padding-block-end: 1rem;
-    padding-inline: 1rem;
+    margin-left: 0;
   }
 </style>

--- a/packages/starlight-openapi/components/operation/OperationUrl.astro
+++ b/packages/starlight-openapi/components/operation/OperationUrl.astro
@@ -19,7 +19,7 @@ const inputAttributes: HTMLAttributes<'input'> = {
   {
     description && description.length > 0 ? (
       <label>
-        {description}
+        <span>{description}</span>
         <input {...inputAttributes} />
       </label>
     ) : (

--- a/packages/starlight-openapi/components/security/Authorizations.astro
+++ b/packages/starlight-openapi/components/security/Authorizations.astro
@@ -1,0 +1,43 @@
+---
+import Key from '../Key.astro'
+---
+
+<div>
+  <h3>Authentication</h3>
+
+  <p>
+    Topsort’s APIs are authenticated via bearer tokens. Requests must include an authorization header containing your
+    private API key.
+  </p>
+
+  <p>Don't have an API key yet? <a href="/api/authentication">Learn how to generate one</a>.</p>
+
+  <div class="sl-oa-schema">
+    <details class="root" open={true}>
+      <summary></summary>
+      <Key name="Authorization" required={true}>
+        <div>
+          <span class="type">string</span>
+        </div>
+
+        <div>
+          <p>The header containing a private API key. Format this header as follows:</p>
+
+          <p><code>Authorization: Bearer &lt;YOUR-API-KEY&gt;</code></p>
+        </div>
+      </Key>
+    </details>
+  </div>
+</div>
+
+<style>
+  details.root > summary {
+    display: none;
+  }
+
+  .type {
+    color: var(--sl-color-text-accent);
+    font-weight: 600;
+    margin-inline-end: 0.3rem;
+  }
+</style>


### PR DESCRIPTION
This PR re-adds an authentication section. This replaces the links that were added below the endpoint information.

The content of this section is hardcoded for now.

The goal is to have it look as follows:

![Screenshot from 2024-08-19 16-21-09](https://github.com/user-attachments/assets/eb65b0e7-4c12-4b5e-aa77-86318e1bde81)
