### PR TITLE
fix: content with single content type have inline labels

### DIFF
--- a/packages/starlight-openapi/components/Content.astro
+++ b/packages/starlight-openapi/components/Content.astro
@@ -19,9 +19,9 @@ const hasOneType = Object.keys(content).length === 1
     <div>
       {Object.entries(content).map(([type, media]) => {
         return (
-          <div class="sl-oa-schema" data-openapi-content-type={type}>
-            <div class="sl-oa-schema-type">{type}</div>
+          <div data-openapi-content-type={type}>
             <Schema
+              contentType={type}
               example={media.example}
               examples={isExamples(media.examples) ? media.examples : undefined}
               schema={isSchemaObject(media.schema) ? media.schema : undefined}

--- a/packages/starlight-openapi/components/schema/Schema.astro
+++ b/packages/starlight-openapi/components/schema/Schema.astro
@@ -8,15 +8,20 @@ import SchemaObject from './SchemaObject.astro'
 interface Props extends ExamplesProps {
   description?: string | undefined
   schema: SchemaObjectType | undefined
+  contentType?: string | undefined
 }
 
-const { description, example, examples, schema } = Astro.props
+const { description, example, examples, schema, contentType } = Astro.props
 
 // For objects, we want to show the description before the object itself.
 const isObject = schema && isSchemaObjectObject(schema)
 ---
 
 {isObject && <Md text={description} />}
-{schema && <SchemaObject schemaObject={schema} hideExample={example !== undefined || examples !== undefined} />}
+{
+  schema && (
+    <SchemaObject schemaObject={schema} hideExample={example !== undefined || examples !== undefined} {contentType} />
+  )
+}
 {!isObject && <Md text={description} />}
 <Examples example={example} examples={examples} />

--- a/packages/starlight-openapi/components/schema/SchemaObject.astro
+++ b/packages/starlight-openapi/components/schema/SchemaObject.astro
@@ -19,9 +19,10 @@ interface Props {
   negated?: boolean
   nested?: boolean
   schemaObject: SchemaObject
+  contentType?: string | undefined
 }
 
-const { negated, nested = false, schemaObject } = Astro.props
+const { negated, nested = false, schemaObject, contentType } = Astro.props
 
 const schemaObjects = getSchemaObjects(schemaObject)
 
@@ -39,7 +40,7 @@ const isNegated = schemaObject.not !== undefined
       <Md text={schemaObject.description} />
       <ExternalDocs docs={schemaObject.externalDocs} />
       {isSchemaObjectObject(schemaObject) ? (
-        <SchemaObjectObject {nested} {schemaObject} />
+        <SchemaObjectObject {nested} {schemaObject} {contentType} />
       ) : isSchemaObjectAllOf(schemaObject) ? (
         <SchemaObjectAllOf {schemaObject} />
       ) : (

--- a/packages/starlight-openapi/components/schema/SchemaObjectObject.astro
+++ b/packages/starlight-openapi/components/schema/SchemaObjectObject.astro
@@ -12,14 +12,16 @@ import SchemaObjectObjectProperties from './SchemaObjectObjectProperties.astro'
 interface Props {
   nested: boolean
   schemaObject: SchemaObject
+  contentType?: string | undefined
 }
 
-const { nested, schemaObject } = Astro.props
+const { nested, schemaObject, contentType } = Astro.props
 
 const properties = getProperties(schemaObject)
 ---
 
 <details class:list={[!nested && 'root']} open={!nested}>
+  <div class="sl-oa-schema-type">{contentType}</div>
   <summary>
     <span class="type">object</span>
     <Icon class="caret" name="right-caret" size="1.25rem" />

--- a/packages/starlight-openapi/components/schema/SchemaObjectObject.astro
+++ b/packages/starlight-openapi/components/schema/SchemaObjectObject.astro
@@ -21,7 +21,7 @@ const properties = getProperties(schemaObject)
 ---
 
 <details class:list={[!nested && 'root']} open={!nested}>
-  <div class="sl-oa-schema-type">{contentType}</div>
+  {contentType !== undefined && <div class="sl-oa-schema-type">{contentType}</div>}
   <summary>
     <span class="type">object</span>
     <Icon class="caret" name="right-caret" size="1.25rem" />


### PR DESCRIPTION
This PR moves the labels deeper into the schema hierarchy, so that they don't appear outside of the [section border](https://github.com/Topsort/docs/pull/225#issuecomment-2324491437).

