### PR TITLE
fix: add api key type per operation

### DIFF
--- a/packages/starlight-openapi/components/operation/Operation.astro
+++ b/packages/starlight-openapi/components/operation/Operation.astro
@@ -27,7 +27,7 @@ const isBeta = pathItemOperation.title.includes('[BETA]')
 <OperationDescription operation={pathItemOperation} {schema} />
 <Md text={operation.description} />
 <ExternalDocs docs={operation.externalDocs} />
-<Authorizations />
+<Authorizations {schema} />
 <Parameters operation={pathItemOperation} />
 <RequestBody {operation} {schema} />
 <Responses {operation} responses={operation.responses} {schema} />

--- a/packages/starlight-openapi/components/security/Authorizations.astro
+++ b/packages/starlight-openapi/components/security/Authorizations.astro
@@ -1,16 +1,49 @@
 ---
+import type { Schema } from '../../libs/schema'
 import Key from '../Key.astro'
+
+interface Props {
+  schema: Schema
+}
+
+interface KeyInfo {
+  name: string
+  private: boolean
+}
+
+const { schema } = Astro.props
+
+// allowlist of openapi files and key types.
+const keyInfoPerFile: Record<string, KeyInfo> = {
+  'openapi/v1.yml': {
+    name: 'Marketplace',
+    private: false,
+  },
+  'openapi/v2.yml': {
+    name: 'Marketplace',
+    private: false,
+  },
+  'openapi/cs.yml': {
+    name: 'Advanced',
+    private: true,
+  },
+}
+
+const key = keyInfoPerFile[schema.config.schema]
+if (key === undefined) {
+  throw new Error(`unknown openapi file ${schema.config.schema}`)
+}
 ---
 
 <div>
   <h3>Authentication</h3>
 
   <p>
-    Topsort’s APIs are authenticated via bearer tokens. Requests must include an authorization header containing your
-    private API key.
+    The Topsort API uses bearer tokens for authentication. Requests must include an authorization header containing a
+    valid API key as a token.
   </p>
 
-  <p>Don't have an API key yet? <a href="/api/authentication">Learn how to generate one</a>.</p>
+  <p>Don't have API key(s) yet? <a href="/api/authentication">Learn how to generate them</a>.</p>
 
   <div class="sl-oa-schema">
     <details class="root" open={true}>
@@ -21,9 +54,20 @@ import Key from '../Key.astro'
         </div>
 
         <div>
-          <p>The header containing a private API key. Format this header as follows:</p>
-
-          <p><code>Authorization: Bearer &lt;YOUR-API-KEY&gt;</code></p>
+          <p>
+            Header containing your <strong>{key.name} API key</strong> as a token.
+            {
+              key.private ? (
+                <span>
+                  <strong>This key is confidential, use it server-side only.</strong>
+                </span>
+              ) : (
+                <span>This key is public, use it on both client and server.</span>
+              )
+            }
+          </p>
+          <p>Header format:</p>
+          <p><code>Authorization: Bearer &lt;YOUR-{key.name.toUpperCase()}-API-KEY&gt;</code></p>
         </div>
       </Key>
     </details>


### PR DESCRIPTION
This PR specifies the API key that is required to authenticate an operation.
- Whether Advanced or Marketplace API keys are required depends on the openapi schema filename.
- The API keys are listed in the component. If an unknown filename is encountered, it will throw an error.
- See images below for the intended layout.

---

![Screenshot from 2024-09-03 12-15-31](https://github.com/user-attachments/assets/bd710ecc-70e2-4b45-a973-ece8abcdb9c1)

---

![Screenshot from 2024-09-03 12-14-52](https://github.com/user-attachments/assets/f91a50f4-036e-46ce-a8c5-bb4f0756905d)
